### PR TITLE
Added ability to render a simple schematic diagram of .obs/.var/.X data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "langevitour>=0.8.0",
     "setuptools<81",
     "red-dwarf",
+    "svgwrite>=1.4.3",
 ]
 
 [build-system]

--- a/src/valency_anndata/viz/__init__.py
+++ b/src/valency_anndata/viz/__init__.py
@@ -1,5 +1,7 @@
 from ._langevitour import langevitour
+from ._schematic_diagram import schematic_diagram
 
 __all__ = [
     "langevitour",
+    "schematic_diagram",
 ]

--- a/src/valency_anndata/viz/_schematic_diagram.py
+++ b/src/valency_anndata/viz/_schematic_diagram.py
@@ -1,0 +1,370 @@
+import math
+import platform
+import subprocess
+import svgwrite
+import tempfile
+from anndata import AnnData
+from typing import TYPE_CHECKING, Any
+
+
+def get_default_browser_name() -> str | None:
+    """
+    Best-effort detection of the system default web browser.
+
+    Returns
+    -------
+    str | None
+        A human-readable browser identifier (e.g. 'Chrome', 'Firefox', 'Safari'),
+        or None if it cannot be determined.
+
+    Notes
+    -----
+    - This is inherently OS-specific and fragile.
+    - Do NOT rely on this for logic or correctness.
+    - Intended for diagnostics, logging, or user-facing messages only.
+    """
+
+    system = platform.system()
+
+    # ------------------
+    # macOS
+    # ------------------
+    if system == "Darwin":
+        try:
+            # Ask LaunchServices for the default HTTP handler
+            cmd = [
+                "plutil",
+                "-p",
+                str(
+                    subprocess.check_output(
+                        [
+                            "defaults",
+                            "read",
+                            "com.apple.LaunchServices/com.apple.launchservices.secure",
+                            "LSHandlers",
+                        ]
+                    )
+                ),
+            ]
+        except Exception:
+            pass
+
+        try:
+            output = subprocess.check_output(
+                [
+                    "defaults",
+                    "read",
+                    "com.apple.LaunchServices/com.apple.launchservices.secure",
+                    "LSHandlers",
+                ],
+                stderr=subprocess.DEVNULL,
+            ).decode()
+
+            for block in output.split("},"):
+                is_url_handler = (
+                    'LSHandlerURLScheme = http' in block
+                    or 'LSHandlerURLScheme = https' in block
+                )
+                if is_url_handler:
+                    for line in block.splitlines():
+                        if "LSHandlerRoleAll" in line or "LSHandlerRoleViewer" in line:
+                            value = line.split("=", 1)[-1].strip().strip('";')
+
+                            # Skip version numbers like "6533.100"
+                            if "." not in value or value.replace(".", "").isdigit():
+                                continue
+
+                            bundle = value.lower()
+
+                            if "chrome" in bundle:
+                                return "Chrome"
+                            if "firefox" in bundle:
+                                return "Firefox"
+                            if "safari" in bundle:
+                                return "Safari"
+                            if "edge" in bundle:
+                                return "Edge"
+
+                            return bundle
+
+        except Exception:
+            pass
+
+    # ------------------
+    # Windows
+    # ------------------
+    if system == "Windows":
+        try:
+            import winreg
+
+            # Suppress type warnings on non-windows platforms
+            if TYPE_CHECKING:
+                winreg: Any
+
+            with winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Microsoft\Windows\Shell\Associations\UrlAssociations\http\UserChoice",
+            ) as key:
+                progid, _ = winreg.QueryValueEx(key, "ProgId")
+
+            progid = progid.lower()
+            if "chrome" in progid:
+                return "Chrome"
+            if "firefox" in progid:
+                return "Firefox"
+            if "edge" in progid:
+                return "Edge"
+            if "safari" in progid:
+                return "Safari"
+
+            return progid
+
+        except Exception:
+            pass
+
+    # ------------------
+    # Linux
+    # ------------------
+    if system == "Linux":
+        try:
+            output = subprocess.check_output(
+                ["xdg-settings", "get", "default-web-browser"],
+                stderr=subprocess.DEVNULL,
+            ).decode().strip().lower()
+
+            if "chrome" in output:
+                return "Chrome"
+            if "firefox" in output:
+                return "Firefox"
+            if "edge" in output:
+                return "Edge"
+            if "safari" in output:
+                return "Safari"
+
+            return output or None
+
+        except Exception:
+            pass
+
+    return None
+
+# ------------------------------------------------------------
+# Environment detection
+# ------------------------------------------------------------
+def in_notebook() -> bool:
+    import sys
+    return "ipykernel" in sys.modules
+
+
+# ------------------------------------------------------------
+# SVG primitives
+# ------------------------------------------------------------
+def draw_grid_block(
+    dwg,
+    *,
+    x,
+    y,
+    width,
+    height,
+    rows,
+    cols,
+    label,
+    stroke="#333",
+    grid_stroke="#ccc",
+):
+    group = dwg.g()
+
+    # Outer rectangle
+    group.add(
+        dwg.rect(
+            insert=(x, y),
+            size=(width, height),
+            fill="none",
+            stroke=stroke,
+            stroke_width=2,
+        )
+    )
+
+    # Horizontal grid
+    if rows > 1:
+        row_h = height / rows
+        for i in range(1, rows):
+            group.add(
+                dwg.line(
+                    start=(x, y + i * row_h),
+                    end=(x + width, y + i * row_h),
+                    stroke=grid_stroke,
+                )
+            )
+
+    # Vertical grid
+    if cols > 1:
+        col_w = width / cols
+        for j in range(1, cols):
+            group.add(
+                dwg.line(
+                    start=(x + j * col_w, y),
+                    end=(x + j * col_w, y + height),
+                    stroke=grid_stroke,
+                )
+            )
+
+    # Label (centered)
+    lines = label.split("\n")
+    line_height = 14
+    start_y = y + height / 2 - (len(lines) - 1) * line_height / 2
+
+    for i, line in enumerate(lines):
+        group.add(
+            dwg.text(
+                line,
+                insert=(x + width / 2, start_y + i * line_height),
+                text_anchor="middle",
+                font_size=12,
+                font_family="sans-serif",
+            )
+        )
+
+    dwg.add(group)
+
+
+# ------------------------------------------------------------
+# AnnData → SVG
+# ------------------------------------------------------------
+def adata_structure_svg(adata: AnnData):
+    cell = 18
+    max_cells = 10
+    pad = 40
+    line_height = 14
+    obs_key_spacing = 15  # horizontal spacing between rotated keys
+
+    obs_cells = min(max_cells, math.ceil(math.sqrt(adata.n_obs)))
+    var_cells = min(max_cells, math.ceil(math.sqrt(adata.n_vars)))
+
+    X_width = var_cells * cell
+    X_height = obs_cells * cell
+
+    # Var block height
+    var_keys = list(adata.var_keys())
+    var_block_height = max(60, len(var_keys) * line_height)
+
+    dwg = svgwrite.Drawing(
+        size=(X_width + 400, X_height + var_block_height + 150),
+        profile="full",
+    )
+
+    x0 = pad + 120
+    y0 = pad + var_block_height + 30  # leave space for var block above
+
+    # -------------------
+    # X block
+    # -------------------
+    draw_grid_block(
+        dwg,
+        x=x0,
+        y=y0,
+        width=X_width,
+        height=X_height,
+        rows=obs_cells,
+        cols=var_cells,
+        label=f"X\n{adata.n_obs} × {adata.n_vars}",
+        stroke="#2ecc71",
+    )
+
+    # -------------------
+    # Obs block (right) - adaptive width
+    # -------------------
+    obs_keys = list(adata.obs_keys())
+    min_obs_width = 60
+    needed_obs_width = len(obs_keys) * obs_key_spacing  # space for rotated keys
+    obs_width = max(min_obs_width, needed_obs_width)
+
+    draw_grid_block(
+        dwg,
+        x=x0 + X_width + 30,
+        y=y0,
+        width=obs_width,
+        height=X_height,
+        rows=obs_cells,
+        cols=1,
+        label=f"obs\n{adata.n_obs} × {adata.obs.shape[1]}",
+        stroke="#3498db",
+    )
+
+    # -------------------
+    # Obs keys (rotated 45° above obs block)
+    # -------------------
+    baseline_y = y0 - 7  # bottom-left corner alignment
+    for i, key in enumerate(obs_keys):
+        x = x0 + X_width + 30 + 10 + i * obs_key_spacing
+        dwg.add(
+            dwg.text(
+                key,
+                insert=(x, baseline_y),
+                font_size=12,
+                font_family="sans-serif",
+                text_anchor="start",
+                transform=f"rotate(-45,{x},{baseline_y})",  # rotate 45° counterclockwise
+            )
+        )
+
+    # -------------------
+    # Var block (top)
+    # -------------------
+    draw_grid_block(
+        dwg,
+        x=x0,
+        y=y0 - var_block_height - 30,
+        width=X_width,
+        height=var_block_height,
+        rows=1,
+        cols=var_cells,
+        label=f"var\n{adata.n_vars} × {adata.var.shape[1]}",
+        stroke="#9b59b6",
+    )
+
+    # Var keys (to the left of var block, bottom-aligned)
+    for i, key in enumerate(var_keys):
+        y = y0 - 27 - (len(var_keys) - i) * line_height + line_height / 2
+        dwg.add(
+            dwg.text(
+                key,
+                insert=(x0 - 10, y),
+                font_size=12,
+                font_family="sans-serif",
+                text_anchor="end",
+            )
+        )
+
+    return dwg
+
+def _display_svg_in_notebook(svg_text: str) -> bool:
+    """Return True if displayed successfully, False otherwise."""
+    try:
+        from IPython.display import SVG, display  # type: ignore[reportMissingImports]
+        display(SVG(svg_text))
+        return True
+    except ImportError:
+        return False
+
+def _show_svg(dwg):
+    svg_text = dwg.tostring()
+    if _display_svg_in_notebook(svg_text):
+        return
+    
+    # Otherwise, assume script mode → open in default browser
+    import webbrowser
+    with tempfile.NamedTemporaryFile(suffix=".svg", delete=False, mode="w") as f:
+        f.write(svg_text)
+        temp_svg_path = f.name
+    browser = get_default_browser_name()
+    if browser:
+        webbrowser.get(browser).open(f"file://{temp_svg_path}")
+        print(f"Opened in your default browser ({browser})")
+    else:
+        webbrowser.open(f"file://{temp_svg_path}")
+        print("Opened in your browser")
+
+def schematic_diagram(adata: AnnData):
+    dwg = adata_structure_svg(adata)
+    _show_svg(dwg)

--- a/uv.lock
+++ b/uv.lock
@@ -2038,6 +2038,15 @@ wheels = [
 ]
 
 [[package]]
+name = "svgwrite"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/c1/263d4e93b543390d86d8eb4fc23d9ce8a8d6efd146f9427364109004fa9b/svgwrite-1.4.3.zip", hash = "sha256:a8fbdfd4443302a6619a7f76bc937fc683daf2628d9b737c891ec08b8ce524c3", size = 189516, upload-time = "2022-07-14T14:05:26.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/15/640e399579024a6875918839454025bb1d5f850bb70d96a11eabb644d11c/svgwrite-1.4.3-py3-none-any.whl", hash = "sha256:bb6b2b5450f1edbfa597d924f9ac2dd099e625562e492021d7dd614f65f8a22d", size = 67122, upload-time = "2022-07-14T14:05:24.459Z" },
+]
+
+[[package]]
 name = "texttable"
 version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2152,6 +2161,7 @@ dependencies = [
     { name = "red-dwarf" },
     { name = "scanpy", extra = ["leiden"] },
     { name = "setuptools" },
+    { name = "svgwrite" },
 ]
 
 [package.metadata]
@@ -2165,6 +2175,7 @@ requires-dist = [
     { name = "red-dwarf", git = "https://github.com/polis-community/red-dwarf" },
     { name = "scanpy", extras = ["leiden"] },
     { name = "setuptools", specifier = "<81" },
+    { name = "svgwrite", specifier = ">=1.4.3" },
 ]
 
 [[package]]


### PR DESCRIPTION
This now renders this, either in a browser (in running from script) or inline HTML (if running from notebook)

```py
import valency_anndata as val

adata = val.datasets.polis.load("https://pol.is/report/r2dfw8eambusb8buvecjt")
adata.obs["foo"] = False
adata.obs["bar"] = False
adata.obs["baz"] = False
adata.obs["some"] = False
adata.obs["other"] = False
adata.obs["stuff"] = False

val.viz.schematic_diagram(adata)
```

<img width="460" height="389" alt="Screenshot 2025-12-17 at 2 14 09 PM" src="https://github.com/user-attachments/assets/42613cb9-73cc-43ff-a0ac-d97553b9625e" />
