### PR TITLE
Support `.obsm` backed color specs in val.viz.embedding

### DIFF
--- a/src/valency_anndata/viz/__init__.py
+++ b/src/valency_anndata/viz/__init__.py
@@ -1,8 +1,8 @@
 from scanpy.plotting._tools.scatterplots import (
-    embedding,
     pca,
     umap,
 )
+from ._embedding import embedding
 from ._langevitour import langevitour
 from ._voter_vignette import voter_vignette_browser
 from ._jupyter_scatter import jscatter

--- a/src/valency_anndata/viz/_embedding.py
+++ b/src/valency_anndata/viz/_embedding.py
@@ -7,7 +7,7 @@ import scanpy as sc
 _COLOR_SPEC_RE = re.compile(
     r"""
     ^
-    (?P<key>[A-Za-z_][A-Za-z0-9_]*) #! possible change?
+    (?P<key>[A-Za-z_][A-Za-z0-9_]*) #! too tight??
     \[
         \s*
         (?:
@@ -127,6 +127,9 @@ def _rewrite_color(adata, color):
 
         adata_plot.obs[color_name] = adata_plot.obsm[key][:, index]
         forwarded.append(color_name)
+
+    if isinstance(expanded, str):
+        return adata_plot, forwarded[0]
 
     return adata_plot, forwarded
 

--- a/src/valency_anndata/viz/_embedding.py
+++ b/src/valency_anndata/viz/_embedding.py
@@ -5,7 +5,7 @@ from typing import Optional, Sequence
 _COLOR_SPEC_RE = re.compile(
     r"""
     ^
-    (?P<key>X_[A-Za-z0-9_]+) #TODO: remeber to change this, matching logic too restritive
+    (?P<key>[A-Za-z_][A-Za-z0-9_]*)
     \[
         \s*
         (?:
@@ -17,7 +17,8 @@ _COLOR_SPEC_RE = re.compile(
     \]
     $
     """,
-    re.VERBOSE,)
+    re.VERBOSE,
+)
 
 
 def _parse_color_spec(color: str) -> Optional[tuple[str, int, Optional[int]]]:
@@ -28,7 +29,7 @@ def _parse_color_spec(color: str) -> Optional[tuple[str, int, Optional[int]]]:
     if not m:
         raise ValueError(
             f"Invalid embedding color spec '{color}'. "
-            "Expected 'X_foo[i]', 'X_foo[a:b]', or 'X_foo[:b]'."
+            "Expected 'foo[i]', 'foo[a:b]', or 'foo[:b]'."
         )
 
     key = m.group("key")
@@ -37,35 +38,47 @@ def _parse_color_spec(color: str) -> Optional[tuple[str, int, Optional[int]]]:
     if index is not None:
         return key, int(index), None
 
-    start = m.group("start")
-    stop = m.group("stop")
+    start = int(m.group("start") or 0)
+    stop_text = m.group("stop")
 
-    if stop == "":
+    if stop_text == "":
         raise ValueError(
-            f"Embedding color spec '{color}' is not supported yet. "
-            "Use 'X_foo[i]', 'X_foo[a:b]', or 'X_foo[:b]'."
+            f"Invalid embedding color slice '{color}'. "
+            "Expected 'foo[a:b]' or 'foo[:b]' with stop > start."
         )
 
-    return key, int(start or 0), int(stop)
+    stop = int(stop_text)
+    if stop <= start:
+        raise ValueError(
+            f"Invalid embedding color slice '{color}'. "
+            "Expected 'foo[a:b]' or 'foo[:b]' with stop > start."
+        )
+
+    return key, start, stop
 
 
-def _expand_color_specs(color: Optional[str | Sequence[str]]): # TODO: reject explictly stop <= start and len()==0 slices
-    if color is None:                                          # Maybe also avoid absurd cases? [:0]?
-        return None   #! The wrapper will have to be bigger because of the outputs, change that...
+def _expand_color_spec(color: str):
+    parsed = _parse_color_spec(color)
+    if parsed is None:
+        return color
+
+    key, start, stop = parsed
+    if stop is None:
+        return color
+
+    return [f"{key}[{i}]" for i in range(start, stop)]
+
+
+def _expand_color_specs(color: Optional[str | Sequence[str]]):
+    if color is None:
+        return None
 
     if isinstance(color, str):
-        parsed = _parse_color_spec(color)
-        if parsed is None:
-            return color
+        return _expand_color_spec(color)
 
-        key, start, stop = parsed
-        if stop is None:
-            return color
-
-        return [f"{key}[{i}]" for i in range(start, stop)] #! X_pca[2:2] becomes []
     expanded = []
     for item in color:
-        item_expanded = _expand_color_specs(item)
+        item_expanded = _expand_color_spec(item)
         if isinstance(item_expanded, list):
             expanded.extend(item_expanded)
         else:

--- a/src/valency_anndata/viz/_embedding.py
+++ b/src/valency_anndata/viz/_embedding.py
@@ -25,7 +25,7 @@ _COLOR_SPEC_RE = re.compile(
 
 def _parse_color_spec(color: str) -> Optional[tuple[str, int, Optional[int]]]:
     if "[" not in color and "]" not in color:
-        return None
+        return None 
 
     m = _COLOR_SPEC_RE.match(color)
     if not m:

--- a/src/valency_anndata/viz/_embedding.py
+++ b/src/valency_anndata/viz/_embedding.py
@@ -1,0 +1,74 @@
+import re
+from typing import Optional, Sequence
+
+
+_COLOR_SPEC_RE = re.compile(
+    r"""
+    ^
+    (?P<key>X_[A-Za-z0-9_]+) #TODO: remeber to change this, matching logic too restritive
+    \[
+        \s*
+        (?:
+            (?P<index>\d+)
+            |
+            (?P<start>\d*)\s*:\s*(?P<stop>\d*)
+        )
+        \s*
+    \]
+    $
+    """,
+    re.VERBOSE,)
+
+
+def _parse_color_spec(color: str) -> Optional[tuple[str, int, Optional[int]]]:
+    if "[" not in color and "]" not in color:
+        return None
+
+    m = _COLOR_SPEC_RE.match(color)
+    if not m:
+        raise ValueError(
+            f"Invalid embedding color spec '{color}'. "
+            "Expected 'X_foo[i]', 'X_foo[a:b]', or 'X_foo[:b]'."
+        )
+
+    key = m.group("key")
+    index = m.group("index")
+
+    if index is not None:
+        return key, int(index), None
+
+    start = m.group("start")
+    stop = m.group("stop")
+
+    if stop == "":
+        raise ValueError(
+            f"Embedding color spec '{color}' is not supported yet. "
+            "Use 'X_foo[i]', 'X_foo[a:b]', or 'X_foo[:b]'."
+        )
+
+    return key, int(start or 0), int(stop)
+
+
+def _expand_color_specs(color: Optional[str | Sequence[str]]): # TODO: reject explictly stop <= start and len()==0 slices
+    if color is None:                                          # Maybe also avoid absurd cases? [:0]?
+        return None   #! The wrapper will have to be bigger because of the outputs, change that...
+
+    if isinstance(color, str):
+        parsed = _parse_color_spec(color)
+        if parsed is None:
+            return color
+
+        key, start, stop = parsed
+        if stop is None:
+            return color
+
+        return [f"{key}[{i}]" for i in range(start, stop)] #! X_pca[2:2] becomes []
+    expanded = []
+    for item in color:
+        item_expanded = _expand_color_specs(item)
+        if isinstance(item_expanded, list):
+            expanded.extend(item_expanded)
+        else:
+            expanded.append(item_expanded)
+
+    return expanded

--- a/src/valency_anndata/viz/_embedding.py
+++ b/src/valency_anndata/viz/_embedding.py
@@ -7,7 +7,7 @@ import scanpy as sc
 _COLOR_SPEC_RE = re.compile(
     r"""
     ^
-    (?P<key>[A-Za-z_][A-Za-z0-9_]*) #! too tight??
+    (?P<key>[A-Za-z_][A-Za-z0-9_]*)
     \[
         \s*
         (?:
@@ -25,7 +25,7 @@ _COLOR_SPEC_RE = re.compile(
 
 def _parse_color_spec(color: str) -> Optional[tuple[str, int, Optional[int]]]:
     if "[" not in color and "]" not in color:
-        return None 
+        return None
 
     m = _COLOR_SPEC_RE.match(color)
     if not m:
@@ -115,7 +115,7 @@ def _rewrite_color(adata, color):
                 f"Color spec '{color_name}' references missing adata.obsm['{key}']."
             )
 
-        X = adata.obsm[key] #! manually reading, we can use scanpy.utils.obs_df/scanpy.get.obs_df?
+        X = adata.obsm[key]
         if index >= X.shape[1]:
             raise IndexError(
                 f"Color spec '{color_name}' is out of bounds for "
@@ -132,6 +132,7 @@ def _rewrite_color(adata, color):
         return adata_plot, forwarded[0]
 
     return adata_plot, forwarded
+
 
 def embedding(adata, *args, color=None, **kwargs):
     adata_plot, color = _rewrite_color(adata, color)

--- a/src/valency_anndata/viz/_embedding.py
+++ b/src/valency_anndata/viz/_embedding.py
@@ -129,3 +129,7 @@ def _rewrite_color(adata, color):
         forwarded.append(color_name)
 
     return adata_plot, forwarded
+
+def embedding(adata, *args, color=None, **kwargs):
+    adata_plot, color = _rewrite_color(adata, color)
+    return sc.pl.embedding(adata_plot, *args, color=color, **kwargs)

--- a/src/valency_anndata/viz/_embedding.py
+++ b/src/valency_anndata/viz/_embedding.py
@@ -1,11 +1,13 @@
 import re
 from typing import Optional, Sequence
 
+import scanpy as sc
+
 
 _COLOR_SPEC_RE = re.compile(
     r"""
     ^
-    (?P<key>[A-Za-z_][A-Za-z0-9_]*)
+    (?P<key>[A-Za-z_][A-Za-z0-9_]*) #! possible change?
     \[
         \s*
         (?:
@@ -85,3 +87,45 @@ def _expand_color_specs(color: Optional[str | Sequence[str]]):
             expanded.append(item_expanded)
 
     return expanded
+
+
+def _rewrite_color(adata, color):
+    expanded = _expand_color_specs(color)
+    if expanded is None:
+        return adata, None
+
+    colors = [expanded] if isinstance(expanded, str) else list(expanded)
+    forwarded = []
+    adata_plot = adata
+
+    for color_name in colors:
+        parsed = _parse_color_spec(color_name)
+        if parsed is None:
+            forwarded.append(color_name)
+            continue
+
+        key, index, stop = parsed
+        if stop is not None:
+            raise ValueError(
+                f"Expected expanded single-column color spec, got '{color_name}'."
+            )
+
+        if key not in adata.obsm:
+            raise KeyError(
+                f"Color spec '{color_name}' references missing adata.obsm['{key}']."
+            )
+
+        X = adata.obsm[key] #! manually reading, we can use scanpy.utils.obs_df/scanpy.get.obs_df?
+        if index >= X.shape[1]:
+            raise IndexError(
+                f"Color spec '{color_name}' is out of bounds for "
+                f"adata.obsm['{key}'] with {X.shape[1]} columns."
+            )
+
+        if adata_plot is adata:
+            adata_plot = adata.copy()
+
+        adata_plot.obs[color_name] = adata_plot.obsm[key][:, index]
+        forwarded.append(color_name)
+
+    return adata_plot, forwarded

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,9 +1,45 @@
+import numpy as np
 import pytest
+from anndata import AnnData
+import scanpy as sc
 
+import valency_anndata as val
 from valency_anndata.viz._embedding import (
     _expand_color_specs,
     _parse_color_spec,
 )
+
+
+def _embedding_adata():
+    adata = AnnData(np.zeros((4, 2)))
+    adata.obs_names = [f"cell_{i}" for i in range(4)]
+    adata.obs["cluster"] = ["a", "b", "a", "b"]
+    adata.obs["kmeans_pacmap"] = ["0", "1", "0", "1"]
+    adata.obsm["X_pca"] = np.array(
+        [
+            [1.0, 2.0, 3.0, 4.0],
+            [5.0, 6.0, 7.0, 8.0],
+            [9.0, 10.0, 11.0, 12.0],
+            [13.0, 14.0, 15.0, 16.0],
+        ]
+    )
+    adata.obsm["evoc_polis2"] = np.array(
+        [
+            [10.0, 20.0],
+            [30.0, 40.0],
+            [50.0, 60.0],
+            [70.0, 80.0],
+        ]
+    )
+    adata.obsm["X_pacmap"] = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 1.0],
+            [2.0, 2.0],
+            [3.0, 3.0],
+        ]
+    )
+    return adata
 
 
 class TestParseColorSpec:
@@ -31,6 +67,12 @@ class TestExpandColorSpecs:
             "X_pca[0]",
             "X_pca[1]",
         ]
+
+    def test_non_x_single_index_stays_single(self):
+        assert _expand_color_specs("evoc_polis[0]") == "evoc_polis[0]"
+
+    def test_plain_key_stays_plain(self):
+        assert _expand_color_specs("cluster") == "cluster"
 
     def test_non_x_slice_expansion(self):
         assert _expand_color_specs("evoc_polis2[1:3]") == [
@@ -68,3 +110,132 @@ class TestExpandColorSpecs:
     def test_invalid_slices_rejected(self, color):
         with pytest.raises(ValueError, match="Invalid embedding color slice"):
             _expand_color_specs(color)
+
+
+class TestEmbeddingWrapper:
+    def test_normal_color_key_forwards_unchanged(self, monkeypatch):
+        adata = _embedding_adata()
+        captured = {}
+
+        def fake_embedding(adata, *args, color=None, **kwargs):
+            captured["adata"] = adata
+            captured["args"] = args
+            captured["color"] = color
+            captured["kwargs"] = kwargs
+            return "ok"
+
+        monkeypatch.setattr(sc.pl, "embedding", fake_embedding)
+
+        result = val.viz.embedding(adata, basis="pacmap", color="cluster", show=False)
+
+        assert result == "ok"
+        assert captured["adata"] is adata
+        assert captured["color"] == "cluster"
+        assert captured["kwargs"]["basis"] == "pacmap"
+
+    def test_single_obsm_color_gets_rewritten(self, monkeypatch):
+        adata = _embedding_adata()
+        captured = {}
+
+        def fake_embedding(adata, *args, color=None, **kwargs):
+            captured["adata"] = adata
+            captured["color"] = color
+            return "ok"
+
+        monkeypatch.setattr(sc.pl, "embedding", fake_embedding)
+
+        val.viz.embedding(adata, basis="pacmap", color="X_pca[2]", show=False)
+
+        assert captured["adata"] is not adata
+        assert captured["color"] == "X_pca[2]"
+        np.testing.assert_array_equal(
+            captured["adata"].obs["X_pca[2]"].to_numpy(),
+            adata.obsm["X_pca"][:, 2],
+        )
+
+    def test_slice_color_gets_expanded_and_rewritten(self, monkeypatch):
+        adata = _embedding_adata()
+        captured = {}
+
+        def fake_embedding(adata, *args, color=None, **kwargs):
+            captured["adata"] = adata
+            captured["color"] = color
+            return "ok"
+
+        monkeypatch.setattr(sc.pl, "embedding", fake_embedding)
+
+        val.viz.embedding(adata, basis="pacmap", color="X_pca[2:4]", show=False)
+
+        assert captured["color"] == ["X_pca[2]", "X_pca[3]"]
+        np.testing.assert_array_equal(
+            captured["adata"].obs["X_pca[2]"].to_numpy(),
+            adata.obsm["X_pca"][:, 2],
+        )
+        np.testing.assert_array_equal(
+            captured["adata"].obs["X_pca[3]"].to_numpy(),
+            adata.obsm["X_pca"][:, 3],
+        )
+
+    def test_mixed_plain_and_obsm_colors_work(self, monkeypatch):
+        adata = _embedding_adata()
+        captured = {}
+
+        def fake_embedding(adata, *args, color=None, **kwargs):
+            captured["adata"] = adata
+            captured["color"] = color
+            return "ok"
+
+        monkeypatch.setattr(sc.pl, "embedding", fake_embedding)
+
+        val.viz.embedding(adata, basis="pacmap", color=["kmeans_pacmap", "X_pca[2]"], show=False)
+
+        assert captured["color"] == ["kmeans_pacmap", "X_pca[2]"]
+        np.testing.assert_array_equal(
+            captured["adata"].obs["X_pca[2]"].to_numpy(),
+            adata.obsm["X_pca"][:, 2],
+        )
+
+    def test_mixed_plain_and_non_x_obsm_colors_work(self, monkeypatch):
+        adata = _embedding_adata()
+        captured = {}
+
+        def fake_embedding(adata, *args, color=None, **kwargs):
+            captured["adata"] = adata
+            captured["color"] = color
+            return "ok"
+
+        monkeypatch.setattr(sc.pl, "embedding", fake_embedding)
+
+        val.viz.embedding(adata, basis="pacmap", color=["cluster", "evoc_polis2[1]"], show=False)
+
+        assert captured["color"] == ["cluster", "evoc_polis2[1]"]
+        np.testing.assert_array_equal(
+            captured["adata"].obs["evoc_polis2[1]"].to_numpy(),
+            adata.obsm["evoc_polis2"][:, 1],
+        )
+
+    def test_original_obs_not_mutated(self, monkeypatch):
+        adata = _embedding_adata()
+        original_columns = list(adata.obs.columns)
+
+        def fake_embedding(adata, *args, color=None, **kwargs):
+            return "ok"
+
+        monkeypatch.setattr(sc.pl, "embedding", fake_embedding)
+
+        val.viz.embedding(adata, basis="pacmap", color="X_pca[2]", show=False)
+
+        assert list(adata.obs.columns) == original_columns
+        assert "X_pca[2]" not in adata.obs.columns
+
+    def test_missing_obsm_key_raises_clear_error(self):
+        adata = _embedding_adata()
+
+        with pytest.raises(KeyError, match="references missing adata.obsm\\['missing'\\]"):
+            val.viz.embedding(adata, basis="pacmap", color="missing[0]", show=False)
+
+    def test_out_of_range_index_raises_clear_error(self):
+        adata = _embedding_adata()
+
+        with pytest.raises(IndexError, match="out of bounds"):
+            val.viz.embedding(adata, basis="pacmap", color="X_pca[10]", show=False)

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,3 +1,6 @@
+import matplotlib
+matplotlib.use("Agg")
+
 import numpy as np
 import pytest
 from anndata import AnnData
@@ -239,3 +242,19 @@ class TestEmbeddingWrapper:
 
         with pytest.raises(IndexError, match="out of bounds"):
             val.viz.embedding(adata, basis="pacmap", color="X_pca[10]", show=False)
+
+
+class TestEmbeddingSmoke:
+    def test_real_plotting_path_runs(self):
+        import matplotlib.pyplot as plt
+
+        adata = _embedding_adata()
+        result = val.viz.embedding(
+            adata,
+            basis="pacmap",
+            color=["cluster", "X_pca[1]"],
+            show=False,
+        )
+
+        assert result is not None
+        plt.close("all")

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -5,12 +5,16 @@ from valency_anndata.viz._embedding import (
     _parse_color_spec,
 )
 
-# TODO: should reject X_pca[2:2], [6:2], [2:](?)
-# TODO : test non "X_" after broader the parser (not just X_pca also?)
 
 class TestParseColorSpec:
     def test_single_index_parse(self):
         assert _parse_color_spec("X_pca[2]") == ("X_pca", 2, None)
+
+    def test_non_x_key_parse(self):
+        assert _parse_color_spec("evoc_polis2[1]") == ("evoc_polis2", 1, None)
+
+    def test_plain_key_returns_none(self):
+        assert _parse_color_spec("cluster") is None
 
 
 class TestExpandColorSpecs:
@@ -28,6 +32,12 @@ class TestExpandColorSpecs:
             "X_pca[1]",
         ]
 
+    def test_non_x_slice_expansion(self):
+        assert _expand_color_specs("evoc_polis2[1:3]") == [
+            "evoc_polis2[1]",
+            "evoc_polis2[2]",
+        ]
+
     def test_mixed_list_preserves_plain_obs_keys(self):
         assert _expand_color_specs(["kmeans_pacmap", "X_pca[2:4]", "pct_seen"]) == [
             "kmeans_pacmap",
@@ -36,10 +46,25 @@ class TestExpandColorSpecs:
             "pct_seen",
         ]
 
+    def test_mixed_list_with_non_x_key(self):
+        assert _expand_color_specs(["cluster", "evoc_polis2[0]"]) == [
+            "cluster",
+            "evoc_polis2[0]",
+        ]
+
     def test_malformed_syntax_rejected(self):
         with pytest.raises(ValueError, match="Invalid embedding color spec"):
             _expand_color_specs("X_pca[nope]")
 
-    def test_bare_full_slice_rejected(self):
-        with pytest.raises(ValueError, match="not supported yet"):
-            _expand_color_specs("X_pca[:]")
+    @pytest.mark.parametrize(
+        "color",
+        [
+            "X_pca[2:]",
+            "X_pca[:]",
+            "X_pca[2:2]",
+            "X_pca[6:2]",
+        ],
+    )
+    def test_invalid_slices_rejected(self, color):
+        with pytest.raises(ValueError, match="Invalid embedding color slice"):
+            _expand_color_specs(color)

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,0 +1,45 @@
+import pytest
+
+from valency_anndata.viz._embedding import (
+    _expand_color_specs,
+    _parse_color_spec,
+)
+
+# TODO: should reject X_pca[2:2], [6:2], [2:](?)
+# TODO : test non "X_" after broader the parser (not just X_pca also?)
+
+class TestParseColorSpec:
+    def test_single_index_parse(self):
+        assert _parse_color_spec("X_pca[2]") == ("X_pca", 2, None)
+
+
+class TestExpandColorSpecs:
+    def test_bounded_slice_expansion(self):
+        assert _expand_color_specs("X_pca[2:6]") == [
+            "X_pca[2]",
+            "X_pca[3]",
+            "X_pca[4]",
+            "X_pca[5]",
+        ]
+
+    def test_prefix_slice_expansion(self):
+        assert _expand_color_specs("X_pca[:2]") == [
+            "X_pca[0]",
+            "X_pca[1]",
+        ]
+
+    def test_mixed_list_preserves_plain_obs_keys(self):
+        assert _expand_color_specs(["kmeans_pacmap", "X_pca[2:4]", "pct_seen"]) == [
+            "kmeans_pacmap",
+            "X_pca[2]",
+            "X_pca[3]",
+            "pct_seen",
+        ]
+
+    def test_malformed_syntax_rejected(self):
+        with pytest.raises(ValueError, match="Invalid embedding color spec"):
+            _expand_color_specs("X_pca[nope]")
+
+    def test_bare_full_slice_rejected(self):
+        with pytest.raises(ValueError, match="not supported yet"):
+            _expand_color_specs("X_pca[:]")


### PR DESCRIPTION
## Summary

Closes #55  

This draft PR is meant to cover a small V1 for supporting `.obsm`-backed color specs in `val.viz.embedding`

Planned scope for this work:

- [x] **Parser / expansion**

  Add private parsing and expansion helpers for color specs like `foo[2]` and bounded slices like `foo[2:6]` while keeping normal `.obs` keys unchanged.

- [x] **`val.viz.embedding` wrapper**

  Replace the current direct re-export with a small wrapper that resolves `.obsm` vector specs, creates temporary `.obs` columns on a copy of `adata`, and then forwards the rewritten `color` argument to `scanpy.pl.embedding`.

- [x] **Tests and polish**

  Add focused unit tests for the parsing and wrapper behavior and plus a small smoke test to make sure the feature works end-to-end without mutating the original `adata`.

For this V1, I’m intentionally keeping the scope pretty "small":

- support `foo[i]`
- support bounded slices like `foo[a:b]`
- allow mixing these with normal `.obs` color keys
- leave `foo[:]` out for now

## Checklist

- [ ] `CHANGELOG.md` updated under `[Unreleased]` (required for user-facing changes)
- [x] Tests added or updated if needed
- [ ] Docs updated if needed