### PR TITLE
Fix schematic_diagram display in marimo notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased][] (YYYY-MM-DD)
 
-_No changes yet._
+### Fixes
+- `val.viz.schematic_diagram()` — fix display in marimo notebooks. It previously only detected Jupyter/IPython, so in marimo it fell through to `webbrowser.open()`, which raised `webbrowser.Error` when no GUI browser was reachable. Now detects marimo via `marimo.running_in_notebook()` and displays inline via `marimo.output.replace(marimo.Html(...))`.
 
 ## [0.4.0][] (2026-07-08)
 

--- a/src/valency_anndata/viz/schematic_diagram/_utils.py
+++ b/src/valency_anndata/viz/schematic_diagram/_utils.py
@@ -5,7 +5,7 @@ import webbrowser
 from ._browser import get_default_browser_name
 
 
-def _display_svg_in_notebook(svg_text: str, meta_filename: Optional[str] = None) -> bool:
+def _display_svg_in_jupyter(svg_text: str, meta_filename: Optional[str] = None) -> bool:
     """
     Attempt to display an SVG string in an IPython/Jupyter notebook.
 
@@ -40,13 +40,44 @@ def _display_svg_in_notebook(svg_text: str, meta_filename: Optional[str] = None)
     display(SVG(svg_text), metadata=metadata)
     return True
 
+def _display_svg_in_marimo(svg_text: str) -> bool:
+    """
+    Attempt to display an SVG string inline in a marimo notebook.
+
+    Parameters
+    ----------
+    svg_text : str
+        The raw SVG content to display.
+
+    Returns
+    -------
+    bool
+        True if the SVG was successfully displayed in a marimo notebook,
+        False otherwise.
+
+    Notes
+    -----
+    - Requires a running marimo kernel. Returns False if marimo is not
+      installed or not currently running a notebook.
+    """
+    try:
+        import marimo
+    except ImportError:
+        return False
+
+    if not marimo.running_in_notebook():
+        return False
+
+    marimo.output.replace(marimo.Html(svg_text))
+    return True
+
 def _show_svg(dwg, filename: Optional[str] = None) -> Optional[str]:
     """
     Display an SVG drawing in the best available environment.
 
-    The function first attempts to render the SVG inline in an IPython/Jupyter
-    notebook. If that fails, it falls back to writing the SVG to a temporary
-    file and opening it in a web browser.
+    The function first attempts to render the SVG inline in a marimo or
+    IPython/Jupyter notebook. If that fails, it falls back to writing the
+    SVG to a temporary file and opening it in a web browser.
 
     Parameters
     ----------
@@ -65,8 +96,10 @@ def _show_svg(dwg, filename: Optional[str] = None) -> Optional[str]:
     """
     svg_text = dwg.tostring()
 
-    # Try inline notebook display first
-    if _display_svg_in_notebook(svg_text, meta_filename=filename):
+    # Try inline notebook display first (marimo, then IPython/Jupyter)
+    if _display_svg_in_marimo(svg_text):
+        return None
+    if _display_svg_in_jupyter(svg_text, meta_filename=filename):
         return None
 
     # Derive a friendly prefix from the provided filename


### PR DESCRIPTION
## Summary
- `schematic_diagram()` only detected Jupyter/IPython via `get_ipython()`, so in marimo it fell through to `webbrowser.open()`, which raises `webbrowser.Error` when no GUI browser is reachable.
- Adds marimo detection via `marimo.running_in_notebook()` and displays inline via `marimo.output.replace(marimo.Html(...))`.
- Renamed `_display_svg_in_notebook` to `_display_svg_in_jupyter` to clarify it's Jupyter-specific now that there's a separate marimo path.

## Test plan
- [x] Reproduced the original `webbrowser.Error` in a live marimo notebook
- [x] Verified `schematic_diagram()` renders inline in marimo after the fix (tested via local editable install)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)