### PR TITLE
Add mask_obs/mask_var params to viz.heatmap; fix japanchoice() loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][] (YYYY-MM-DD)
 
+### Added
+- `val.viz.heatmap()` — new `mask_obs` and `mask_var` parameters for subsetting the plotted matrix, following scanpy's mask convention (boolean array or the name of a boolean `adata.obs`/`adata.var` column). Useful for excluding participants with no `groupby` assignment (e.g. unclustered rows) and moderated-out statements.
+
 ### Fixes
 - `val.viz.schematic_diagram()` — fix display in marimo notebooks. It previously only detected Jupyter/IPython, so in marimo it fell through to `webbrowser.open()`, which raised `webbrowser.Error` when no GUI browser was reachable. Now detects marimo via `marimo.running_in_notebook()` and displays inline via `marimo.output.replace(marimo.Html(...))`.
 - `val.datasets.japanchoice()` — the source pol.is conversations were taken down; loading now pulls CSV exports archived on [huggingface.co/patcon](https://huggingface.co/patcon) instead. `"2025_diversity_human_rights"` and `"2025_education_children_old_age"` have no archive and now raise a clear `ValueError` instead of silently failing against a dead pol.is URL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 - `val.viz.schematic_diagram()` — fix display in marimo notebooks. It previously only detected Jupyter/IPython, so in marimo it fell through to `webbrowser.open()`, which raised `webbrowser.Error` when no GUI browser was reachable. Now detects marimo via `marimo.running_in_notebook()` and displays inline via `marimo.output.replace(marimo.Html(...))`.
+- `val.datasets.japanchoice()` — the source pol.is conversations were taken down; loading now pulls CSV exports archived on [huggingface.co/patcon](https://huggingface.co/patcon) instead. `"2025_diversity_human_rights"` and `"2025_education_children_old_age"` have no archive and now raise a clear `ValueError` instead of silently failing against a dead pol.is URL.
 
 ## [0.4.0][] (2026-07-08)
 

--- a/src/valency_anndata/datasets/_load_japanchoice.py
+++ b/src/valency_anndata/datasets/_load_japanchoice.py
@@ -13,15 +13,20 @@ JapanChoiceTopic = Literal[
     "2026_economy_taxation_employment",
 ]
 
-_TOPIC_URLS = {
-    "2025_foreign_affairs_security": "https://pol.is/7cdcyjmsyh",
-    "2025_diversity_human_rights": "https://pol.is/3rdyhjcbxx",
-    "2025_education_children_old_age": "https://pol.is/99y92pjk4z",
-    "2025_economy_taxation_employment": "https://pol.is/6awww43xxn",
-    "2026_foreign_affairs_security": "https://pol.is/3x3ancmrtc",
-    "2026_diversity_human_rights": "https://pol.is/3t4j7mpbm8",
-    "2026_education_children_old_age": "https://pol.is/98xdmajxvb",
-    "2026_economy_taxation_employment": "https://pol.is/7sfbub9can",
+_TOPIC_SOURCES = {
+    "2025_foreign_affairs_security": "huggingface:patcon/japanchoice-2025-foreign-policy-and-security",
+    "2025_economy_taxation_employment": "huggingface:patcon/japanchoice-2025-economy-taxation-employment",
+    "2026_foreign_affairs_security": "huggingface:patcon/japanchoice-2026-foreign-policy-and-security",
+    "2026_diversity_human_rights": "huggingface:patcon/japanchoice-2026-diversity-and-human-rights",
+    "2026_education_children_old_age": "huggingface:patcon/japanchoice-2026-education-children-old-age",
+    "2026_economy_taxation_employment": "huggingface:patcon/japanchoice-2026-economy-taxation-employment",
+}
+
+# Topics that were once available at pol.is but have since been taken down,
+# with no HuggingFace archive to fall back on.
+_UNAVAILABLE_TOPICS = {
+    "2025_diversity_human_rights",
+    "2025_education_children_old_age",
 }
 
 
@@ -37,6 +42,9 @@ def japanchoice(
     elections, allowing citizens to share and compare their views on national issues.
     Conversations are in Japanese.
 
+    Data is archived as CSV exports on HuggingFace, under
+    <https://huggingface.co/patcon>.
+
     See: <https://japanchoice.jp/polis>
 
     Parameters
@@ -45,13 +53,18 @@ def japanchoice(
         The policy topic and year to load. One of:
 
         - ``"2025_foreign_affairs_security"`` — Foreign Affairs & Security (2025)
-        - ``"2025_diversity_human_rights"`` — Diversity & Human Rights (2025)
-        - ``"2025_education_children_old_age"`` — Education, Children & Old Age Care (2025)
+        - ``"2025_diversity_human_rights"`` — Diversity & Human Rights (2025) — **no longer available**
+        - ``"2025_education_children_old_age"`` — Education, Children & Old Age Care (2025) — **no longer available**
         - ``"2025_economy_taxation_employment"`` — Economy, Taxation & Employment (2025)
         - ``"2026_foreign_affairs_security"`` — Foreign Affairs & Security (2026)
         - ``"2026_diversity_human_rights"`` — Diversity & Human Rights (2026)
         - ``"2026_education_children_old_age"`` — Education, Children & Old Age Care (2026)
         - ``"2026_economy_taxation_employment"`` — Economy, Taxation & Employment (2026)
+
+        The topics marked "no longer available" were originally hosted as
+        live pol.is conversations but have since been taken down, and no
+        HuggingFace archive currently exists for them. Requesting one of
+        these raises a ``ValueError``.
 
     translate_to : str or None, optional
         Target language code (e.g., ``"en"``, ``"fr"``) for translating
@@ -84,10 +97,18 @@ def japanchoice(
     <https://github.com/compdemocracy/polis>) and is sub-licensed under CC BY
     4.0 with Attribution to The Computational Democracy Project.
     """
-    if topic not in _TOPIC_URLS:
-        raise ValueError(f"Unknown topic {topic!r}. Must be one of: {list(_TOPIC_URLS)}")
-    url = _TOPIC_URLS[topic]
+    if topic in _UNAVAILABLE_TOPICS:
+        raise ValueError(
+            f"The {topic!r} dataset is no longer available. It was "
+            "originally hosted as a live pol.is conversation, which has "
+            "since been taken down, and no HuggingFace archive currently "
+            "exists for it."
+        )
 
-    adata = val.datasets.polis.load(url, translate_to=translate_to, **kwargs)
+    if topic not in _TOPIC_SOURCES:
+        raise ValueError(f"Unknown topic {topic!r}. Must be one of: {list(JapanChoiceTopic.__args__)}")
+    source = _TOPIC_SOURCES[topic]
+
+    adata = val.datasets.polis.load(source, translate_to=translate_to, **kwargs)
 
     return adata

--- a/src/valency_anndata/datasets/_load_japanchoice.py
+++ b/src/valency_anndata/datasets/_load_japanchoice.py
@@ -106,7 +106,9 @@ def japanchoice(
         )
 
     if topic not in _TOPIC_SOURCES:
-        raise ValueError(f"Unknown topic {topic!r}. Must be one of: {list(JapanChoiceTopic.__args__)}")
+        raise ValueError(
+            f"Unknown topic {topic!r}. Must be one of: {list(JapanChoiceTopic.__args__)}"
+        )
     source = _TOPIC_SOURCES[topic]
 
     adata = val.datasets.polis.load(source, translate_to=translate_to, **kwargs)

--- a/src/valency_anndata/viz/_heatmap.py
+++ b/src/valency_anndata/viz/_heatmap.py
@@ -7,22 +7,26 @@ from matplotlib.colors import ListedColormap, BoundaryNorm
 from matplotlib import colormaps as _mpl_colormaps, pyplot as _plt
 
 
-def _resolve_obs_mask(adata: AnnData, mask_obs: "np.ndarray | str | None") -> "np.ndarray | None":
-    """Resolve ``mask_obs`` to a boolean array, following scanpy's mask_obs convention."""
-    if mask_obs is None:
+def _resolve_mask(
+    adata: AnnData, mask: "np.ndarray | str | None", dim: str
+) -> "np.ndarray | None":
+    """Resolve ``mask_obs``/``mask_var`` to a boolean array, per scanpy's mask convention."""
+    if mask is None:
         return None
-    if isinstance(mask_obs, str):
-        if mask_obs not in adata.obs.columns:
-            msg = f"Did not find `adata.obs[{mask_obs!r}]`."
+    annot = getattr(adata, dim)
+    n = adata.n_obs if dim == "obs" else adata.n_vars
+    if isinstance(mask, str):
+        if mask not in annot.columns:
+            msg = f"Did not find `adata.{dim}[{mask!r}]`."
             raise ValueError(msg)
-        mask_array = adata.obs[mask_obs].to_numpy()
+        mask_array = annot[mask].to_numpy()
     else:
-        mask_array = np.asarray(mask_obs)
-        if len(mask_array) != adata.n_obs:
-            msg = "The shape of the mask does not match adata.n_obs."
+        mask_array = np.asarray(mask)
+        if len(mask_array) != n:
+            msg = f"The shape of the mask does not match adata.n_{dim}."
             raise ValueError(msg)
     if not pd.api.types.is_bool_dtype(mask_array.dtype):
-        msg = "mask_obs array must be boolean."
+        msg = f"mask_{dim} array must be boolean."
         raise ValueError(msg)
     return mask_array
 
@@ -51,6 +55,7 @@ def heatmap(
     adata: AnnData,
     groupby: str | None = None,
     mask_obs: np.ndarray | str | None = None,
+    mask_var: np.ndarray | str | None = None,
     cmap: str = "RdYlGn",
     discrete: bool = False,
     show_labels: bool = True,
@@ -76,6 +81,11 @@ def heatmap(
         participants to include, following scanpy's ``mask_obs`` convention
         (see e.g. :func:`scanpy.pl.pca`). Useful for excluding participants
         with no ``groupby`` assignment (e.g. unclustered rows).
+    mask_var
+        Boolean mask (or name of a boolean ``adata.var`` column) selecting
+        which statements to include, following scanpy's ``mask_var``
+        convention (see e.g. :func:`scanpy.pp.pca`). Useful for excluding
+        moderated-out statements, e.g. ``mask_var=(adata.var["moderation_state"] >= 1).to_numpy()``.
     cmap
         Colormap name. Defaults to ``"RdYlGn"``. Also accepts ``"RdYlGnBright"``,
         a custom :class:`~matplotlib.colors.ListedColormap` with fully saturated
@@ -117,9 +127,13 @@ def heatmap(
     import scanpy as sc
     import matplotlib.pyplot as plt
 
-    mask_array = _resolve_obs_mask(adata, mask_obs)
-    if mask_array is not None:
-        adata = adata[mask_array].copy()
+    obs_mask_array = _resolve_mask(adata, mask_obs, "obs")
+    var_mask_array = _resolve_mask(adata, mask_var, "var")
+    if obs_mask_array is not None or var_mask_array is not None:
+        adata = adata[
+            obs_mask_array if obs_mask_array is not None else slice(None),
+            var_mask_array if var_mask_array is not None else slice(None),
+        ].copy()
 
     _dummy_col = None
     if groupby is None:

--- a/src/valency_anndata/viz/_heatmap.py
+++ b/src/valency_anndata/viz/_heatmap.py
@@ -1,9 +1,30 @@
 from __future__ import annotations
 
 import numpy as np
+import pandas as pd
 from anndata import AnnData
 from matplotlib.colors import ListedColormap, BoundaryNorm
 from matplotlib import colormaps as _mpl_colormaps, pyplot as _plt
+
+
+def _resolve_obs_mask(adata: AnnData, mask_obs: "np.ndarray | str | None") -> "np.ndarray | None":
+    """Resolve ``mask_obs`` to a boolean array, following scanpy's mask_obs convention."""
+    if mask_obs is None:
+        return None
+    if isinstance(mask_obs, str):
+        if mask_obs not in adata.obs.columns:
+            msg = f"Did not find `adata.obs[{mask_obs!r}]`."
+            raise ValueError(msg)
+        mask_array = adata.obs[mask_obs].to_numpy()
+    else:
+        mask_array = np.asarray(mask_obs)
+        if len(mask_array) != adata.n_obs:
+            msg = "The shape of the mask does not match adata.n_obs."
+            raise ValueError(msg)
+    if not pd.api.types.is_bool_dtype(mask_array.dtype):
+        msg = "mask_obs array must be boolean."
+        raise ValueError(msg)
+    return mask_array
 
 # Register a brighter discrete-friendly variant of RdYlGn.
 # Takes the red and green endpoints directly from RdYlGn, but overrides
@@ -29,6 +50,7 @@ except ValueError:
 def heatmap(
     adata: AnnData,
     groupby: str | None = None,
+    mask_obs: np.ndarray | str | None = None,
     cmap: str = "RdYlGn",
     discrete: bool = False,
     show_labels: bool = True,
@@ -49,6 +71,11 @@ def heatmap(
     groupby
         Column in ``adata.obs`` to group participants by. When ``None``,
         participants are shown in their current index order with no grouping.
+    mask_obs
+        Boolean mask (or name of a boolean ``adata.obs`` column) selecting which
+        participants to include, following scanpy's ``mask_obs`` convention
+        (see e.g. :func:`scanpy.pl.pca`). Useful for excluding participants
+        with no ``groupby`` assignment (e.g. unclustered rows).
     cmap
         Colormap name. Defaults to ``"RdYlGn"``. Also accepts ``"RdYlGnBright"``,
         a custom :class:`~matplotlib.colors.ListedColormap` with fully saturated
@@ -89,6 +116,10 @@ def heatmap(
     """
     import scanpy as sc
     import matplotlib.pyplot as plt
+
+    mask_array = _resolve_obs_mask(adata, mask_obs)
+    if mask_array is not None:
+        adata = adata[mask_array].copy()
 
     _dummy_col = None
     if groupby is None:

--- a/src/valency_anndata/viz/_heatmap.py
+++ b/src/valency_anndata/viz/_heatmap.py
@@ -30,6 +30,7 @@ def _resolve_mask(
         raise ValueError(msg)
     return mask_array
 
+
 # Register a brighter discrete-friendly variant of RdYlGn.
 # Takes the red and green endpoints directly from RdYlGn, but overrides
 # the muted midpoint yellow with a fully saturated yellow (#ffff00).


### PR DESCRIPTION
## Summary

Two related-in-passing changes to make `val.viz.heatmap()` usable on real (messy) Polis data:

### `val.viz.heatmap()` — `mask_obs` / `mask_var`

New optional params for subsetting the plotted matrix, following scanpy's mask convention (a boolean array, or the name of a boolean column in `adata.obs` / `adata.var`):

- `mask_obs` — exclude participants, e.g. rows with no `groupby` assignment (unclustered participants).
- `mask_var` — exclude statements, e.g. `mask_var=(adata.var["moderation_state"] >= 1).to_numpy()` to drop moderated-out statements.

Masks are resolved by a shared `_resolve_mask()` helper that mirrors scanpy's validation (missing column, shape mismatch, non-boolean dtype all raise `ValueError`), then applied as a single `adata[obs, var].copy()` subset before plotting.

### `val.datasets.japanchoice()` — fix loading

The source pol.is conversations were taken down, so this loader was silently failing against dead URLs. Loading now pulls CSV exports archived on [huggingface.co/patcon](https://huggingface.co/patcon). The two topics with no archive (`"2025_diversity_human_rights"`, `"2025_education_children_old_age"`) now raise a clear `ValueError`.

## Test plan

- `make test` — 215 passed, 6 skipped
- `uv run ruff check` / `ruff format` clean on touched files
- Changelog updated under `[Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)